### PR TITLE
Update bevy to 0.18.0, native-dialog to 0.9.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ default = ["log"]
 log = ["bevy/bevy_log"]
 
 [dependencies]
-bevy = { version = "0.17.0", default-features = false }
-native-dialog = "0.9.2"
+bevy = { version = "0.18.0", default-features = false }
+native-dialog = "0.9.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy-panic-handler"
-version = "6.0.0"
+version = "7.0.0"
 edition = "2021"
 authors = ["Daniel Yoon"]
 description = "A Bevy plugin that creates a popup message and logs to error on panic"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Check examples for more usages.
 
 | Bevy | `bevy-panic-handler` |
 | ---- | -------------------- |
+| 0.18 |                7.0.0 |
 | 0.17 |                6.0.0 |
 | 0.16 |                5.0.0 |
 | 0.15 |                4.0.0 |


### PR DESCRIPTION
Tested the examples such as `cargo run --example popup`